### PR TITLE
fix implicity any with tslint

### DIFF
--- a/lib/monaco-editor-loader/monaco-editor-loader.directive.ts
+++ b/lib/monaco-editor-loader/monaco-editor-loader.directive.ts
@@ -3,7 +3,7 @@ import { MonacoEditorLoaderService } from './monaco-editor-loader.service';
 
 @Directive({ selector: '[loadMonacoEditor]' })
 export class MonacoEditorLoaderDirective {
-    @Input() set loadMonacoEditor(value) {
+    @Input() set loadMonacoEditor(value: any) {
         this.monacoEditorLoaderService.monacoPath = value;
     }
 

--- a/lib/monaco-editor-loader/monaco-editor-loader.service.ts
+++ b/lib/monaco-editor-loader/monaco-editor-loader.service.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 export class MonacoEditorLoaderService {
     isMonacoLoaded: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
     private _monacoPath = 'assets/monaco-editor/vs';
-    set monacoPath(value) {
+    set monacoPath(value: any) {
         if (value) {
             this._monacoPath = value;
         }


### PR DESCRIPTION
Angular 5 projects with strict tslint rules enabled fail to build because of implicit any. This is a simple fix for that.